### PR TITLE
Adjusted readme

### DIFF
--- a/packages/aws-cdk-lib/aws-codepipeline-actions/README.md
+++ b/packages/aws-cdk-lib/aws-codepipeline-actions/README.md
@@ -112,6 +112,7 @@ const eventPattern = {
   },
 };
 declare const repo: codecommit.Repository;
+declare const lambdaFuntion: lambda.LambdaFunction;
 const sourceOutput = new codepipeline.Artifact();
 const sourceAction = new codepipeline_actions.CodeCommitSourceAction({
   actionName: 'CodeCommit',
@@ -119,11 +120,7 @@ const sourceAction = new codepipeline_actions.CodeCommitSourceAction({
   output: sourceOutput,
   customEventRule: {
     eventPattern,
-    target: new LambdaFunction(new Function(stack, 'TestFunction', {
-      code: Code.fromInline('foo'),
-      handler: 'bar',
-      runtime: Runtime.NODEJS_LATEST,
-    })),
+    target: lambdaFuntion,
   }
 });
 ```


### PR DESCRIPTION
> REPLACE THIS TEXT BLOCK
>
> Describe the reason for this change, what the solution is, and any
> important design decisions you made. 
>
> Remember to follow the [CONTRIBUTING GUIDE] and [DESIGN GUIDELINES] for any
> code you submit.
>
> [CONTRIBUTING GUIDE]: https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md
> [DESIGN GUIDELINES]: https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md

Closes #<issue number here>.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # Pull Request Description
> 
> ## TL;DR
> This pull request refactors the `aws-codepipeline-actions` README.md file to use a declared `lambdaFunction` instead of creating a new one within the `CodeCommitSourceAction` declaration.
> 
> ## What changed
> The `CodeCommitSourceAction` declaration in the README.md file of `aws-codepipeline-actions` package was updated. Instead of creating a new `LambdaFunction` within the `target` field, it now uses a previously declared `lambdaFunction`.
> 
> ```diff
> -    target: new LambdaFunction(new Function(stack, 'TestFunction', {
> -      code: Code.fromInline('foo'),
> -      handler: 'bar',
> -      runtime: Runtime.NODEJS_LATEST,
> -    })),
> +    target: lambdaFuntion,
> ```
> 
> ## How to test
> To test this change, follow the instructions in the README.md file to set up a `CodeCommitSourceAction` using a `lambdaFunction`. Ensure that the pipeline works as expected with the `lambdaFunction` as the target.
> 
> ## Why make this change
> This change simplifies the code and makes it easier to understand. It also promotes the use of declared variables, which can be more efficient and easier to manage in larger codebases.
</details>